### PR TITLE
Add user profile endpoint and serializer

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from rest_framework import serializers
+from observations.serializers import ObservationGeoSerializer
 
 User = get_user_model()
 
@@ -25,3 +26,13 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ("id", "email", "username", "role", "created_at", "updated_at")
         read_only_fields = ("id", "role", "created_at", "updated_at")
+
+class UserProfileSerializer(UserSerializer):
+    observation_count = serializers.SerializerMethodField()
+    observations = ObservationGeoSerializer(many=True, read_only=True)
+
+    class Meta(UserSerializer.Meta):
+        fields = UserSerializer.Meta.fields + ("observation_count", "observations")
+
+    def get_observation_count(self, obj):
+        return obj.observations.count()

--- a/backend/users/test_users.py
+++ b/backend/users/test_users.py
@@ -8,6 +8,7 @@ class TestUserAuth:
     login_url = "/api/v1/auth/login/"
     user_url = "/api/v1/auth/user/"
     refresh_url = "/api/v1/auth/refresh/"
+    profile_me_url = "/api/v1/auth/profiles/me/"
 
     @pytest.fixture
     def client(self):
@@ -117,3 +118,86 @@ class TestUserAuth:
         refresh_resp2 = client.post(self.refresh_url, {"refresh": refresh}, format="json")
         assert refresh_resp2.status_code == 200
         assert "access" in refresh_resp2.data
+
+    def create_observation_for_user(self, client, token, payload_override=None):
+        """
+        Helper to create an observation for the current authenticated user.
+        You may need to adjust this based on your /observations/ endpoint structure.
+        """
+        obs_url = "/api/v1/observations/"
+        payload = {
+            "species_name": "Test Fish",
+            "observation_datetime": "2024-10-29T12:00:00Z",
+            "location": "POINT(1.0 2.0)",
+            "location_name": "Test Reef",
+            "depth": 5.0,
+            "temperature": 20.2,
+            "visibility": 15.1,
+            "notes": "Test observation note"
+        }
+        if payload_override:
+            payload.update(payload_override)
+        client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        resp = client.post(obs_url, payload, format="json")
+        assert resp.status_code in (200, 201)
+        return resp.data
+
+    def test_profile_me_requires_auth(self, client):
+        resp = client.get(self.profile_me_url)
+        assert resp.status_code in (401, 403)
+
+    def test_profile_me_no_observations(self, client, register_user):
+        login = client.post(self.login_url, {
+            "username": "diverbob",
+            "email": "user@example.com",
+            "password": "testpassword123",
+            "role": "hobbyist"
+        }, format="json")
+        token = login.data["access"]
+        client.credentials(HTTP_AUTHORIZATION='Bearer ' + token)
+        resp = client.get(self.profile_me_url)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "observation_count" in data
+        assert data["observation_count"] == 0
+        assert "observations" in data
+        features = data["observations"]["features"]
+        assert features == []
+
+    def test_profile_me_with_observations(self, client, register_user):
+        login = client.post(self.login_url, {
+            "username": "diverbob",
+            "email": "user@example.com",
+            "password": "testpassword123",
+            "role": "hobbyist"
+        }, format="json")
+        token = login.data["access"]
+        self.create_observation_for_user(client, token)
+        resp = client.get(self.profile_me_url)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["observation_count"] == 1
+        features = data["observations"]["features"]
+        assert len(features) == 1
+        obs_props = features[0]["properties"]
+        assert obs_props["species_name"] == "Test Fish"
+        assert obs_props["location_name"] == "Test Reef"
+
+    def test_profile_me_multiple_observations(self, client, register_user):
+        login = client.post(self.login_url, {
+            "username": "diverbob",
+            "email": "user@example.com",
+            "password": "testpassword123",
+            "role": "hobbyist"
+        }, format="json")
+        token = login.data["access"]
+        self.create_observation_for_user(client, token)
+        self.create_observation_for_user(client, token, payload_override={"species_name": "Shark"})
+        resp = client.get(self.profile_me_url)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["observation_count"] == 2
+        features = data["observations"]["features"]
+        observed_species = [f["properties"]["species_name"] for f in features]
+        assert "Test Fish" in observed_species
+        assert "Shark" in observed_species

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('register/', views.RegisterView.as_view(), name='auth_register'),
     path('user/', views.UserDetailView.as_view(), name='auth_user'),
+    path('profiles/me/', views.ProfileMeView.as_view(), name='profile_me'),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,6 +1,6 @@
 from rest_framework import generics, permissions
 from django.contrib.auth import get_user_model
-from .serializers import UserSerializer, RegisterSerializer
+from .serializers import UserSerializer, RegisterSerializer, UserProfileSerializer
 
 class RegisterView(generics.CreateAPIView):
     queryset = get_user_model().objects.all()
@@ -9,6 +9,13 @@ class RegisterView(generics.CreateAPIView):
 
 class UserDetailView(generics.RetrieveUpdateAPIView):
     serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_object(self):
+        return self.request.user
+
+class ProfileMeView(generics.RetrieveAPIView):
+    serializer_class = UserProfileSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_object(self):


### PR DESCRIPTION
- Introduced UserProfileSerializer to include observation count and related observations in user profiles.
- Added ProfileMeView to handle requests for the authenticated user's profile.
- Updated URL patterns to include a new endpoint for fetching user profile data.
- Enhanced tests to validate the profile retrieval functionality, including scenarios with and without observations.
