### PR TITLE
Refactor cookie handling and CORS settings in backend

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -151,12 +151,8 @@ SIMPLE_JWT = {
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),  # Recommended: 7 days
     "ROTATE_REFRESH_TOKENS": True,  # Recommended: Enabled
     "AUTH_HEADER_TYPES": ("Bearer",),
-    "AUTH_COOKIE": (
-        "access_token"
-    ),  # The name of the cookie for the access token
-    "AUTH_COOKIE_REFRESH": (
-        "refresh_token"
-    ),  # The name of the cookie for the refresh token
+    "AUTH_COOKIE": "access_token",
+    "AUTH_COOKIE_REFRESH": "refresh_token",
     "AUTH_COOKIE_DOMAIN": os.getenv("AUTH_COOKIE_DOMAIN", None),
     "AUTH_COOKIE_SECURE": True,  # Recommended: Secure
     "AUTH_COOKIE_HTTP_ONLY": True,  # Recommended: HttpOnly
@@ -169,7 +165,7 @@ SIMPLE_JWT = {
 # =============================================================================
 CORS_ALLOW_CREDENTIALS = True
 
-# Default dev origins (use env for prod!)
+# Default dev origins
 CORS_ALLOWED_ORIGINS = os.getenv(
     "CORS_ALLOWED_ORIGINS",
     "http://localhost:3000,http://127.0.0.1:3000,http://0.0.0.0",
@@ -190,7 +186,6 @@ if DEBUG or ENV == "development":
     # Optional: For DRF Swagger etc. in dev, you may want all hosts
     ALLOWED_HOSTS = ["*"]
     SECURE_HSTS_SECONDS = 0
-    # CORS/URLs already set for dev above
 else:
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -46,14 +46,22 @@ class EmailTokenObtainPairView(TokenObtainPairView):
         response = super().post(request, *args, **kwargs)
         if response.status_code == 200 and "access" in response.data:
             access_token = response.data["access"]
+
+            # Get settings from SIMPLE_JWT config
+            jwt_settings = settings.SIMPLE_JWT
+
             response.set_cookie(
-                key="access_token",
+                key=jwt_settings.get("AUTH_COOKIE", "access_token"),
                 value=access_token,
-                httponly=True,
-                secure=not settings.DEBUG,
-                samesite="Lax",
+                httponly=jwt_settings.get("AUTH_COOKIE_HTTP_ONLY", True),
+                secure=jwt_settings.get(
+                    "AUTH_COOKIE_SECURE", not settings.DEBUG
+                ),
+                samesite=jwt_settings.get("AUTH_COOKIE_SAMESITE", "Lax"),
+                # Use the domain from settings!
+                domain=jwt_settings.get("AUTH_COOKIE_DOMAIN"),
                 max_age=24 * 60 * 60,
-                path="/",
+                path=jwt_settings.get("AUTH_COOKIE_PATH", "/"),
             )
         return response
 

--- a/frontend/src/components/MapComponent.tsx
+++ b/frontend/src/components/MapComponent.tsx
@@ -49,7 +49,6 @@ export default function MapComponent({
   zoomTrigger,
   mapRefreshTrigger,
 }: MapComponentProps) {
-  // Make sure selectedObservation is destructured
   const defaultPosition: [number, number] = [0, 0];
   const [allMapObservations, setAllMapObservations] = useState<
     GeoJsonFeature[]
@@ -99,7 +98,7 @@ export default function MapComponent({
     <MapContainer
       center={defaultPosition}
       zoom={2}
-      minZoom={2} // Prevents zooming out too far
+      minZoom={2}
       worldCopyJump
       scrollWheelZoom
       className="h-full w-full"
@@ -134,7 +133,7 @@ export default function MapComponent({
                   popupClassName = "popup-pending";
                   break;
                 default:
-                  popupClassName = ""; // No specific class for default or unknown status
+                  popupClassName = "";
               }
             } else {
               popupClassName = "popup-external";

--- a/infra/terraform/user-data.sh
+++ b/infra/terraform/user-data.sh
@@ -119,7 +119,7 @@ LOGGING_LEVEL=${logging_level}
 ALLOWED_HOSTS=${api_domain},localhost,backend,species-backend
 CORS_ALLOWED_ORIGINS=https://${frontend_domain}
 CSRF_TRUSTED_ORIGINS=https://${frontend_domain}
-AUTH_COOKIE_DOMAIN=.${frontend_domain}
+AUTH_COOKIE_DOMAIN=.kuroshio-lab.com
 
 # AWS
 USE_S3=True


### PR DESCRIPTION
- Simplified AUTH_COOKIE and AUTH_COOKIE_REFRESH definitions in SIMPLE_JWT settings.
- Updated EmailTokenObtainPairView to utilize settings for cookie attributes.
- Cleaned up comments in settings.py and adjusted CORS_ALLOWED_ORIGINS for clarity.
- Set AUTH_COOKIE_DOMAIN in user-data.sh for production consistency.
