### PR TITLE
feat: Implement trusted email domain management and auto-approval logic

### DIFF
--- a/backend/users/management/commands/seed_trusted_domains.py
+++ b/backend/users/management/commands/seed_trusted_domains.py
@@ -1,0 +1,82 @@
+from django.core.management.base import BaseCommand
+
+from users.models import TrustedEmailDomain
+
+TRUSTED_DOMAINS = [
+    {
+        "domain": "marine.csiro.au",
+        "organization_name": "CSIRO Marine and Atmospheric Research",
+    },
+    {
+        "domain": "kuroshio-lab.com",
+        "organization_name": "intern admin",
+    },
+    {
+        "domain": "mbari.org",
+        "organization_name": "Monterey Bay Aquarium Research Institute",
+    },
+    {
+        "domain": "noaa.gov",
+        "organization_name": "National Oceanic and Atmospheric Administration",
+    },
+    {
+        "domain": "edu",
+        "organization_name": "US Educational Institutions",
+        "notes": "Suffix match: covers all *.edu domains",
+    },
+    {
+        "domain": "gov",
+        "organization_name": "US Government Agencies",
+        "notes": "Suffix match: covers all *.gov domains",
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Seed the TrustedEmailDomain table with default trusted domains"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be created without making changes",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        created_count = 0
+        skipped_count = 0
+
+        for entry in TRUSTED_DOMAINS:
+            domain = entry["domain"]
+            exists = TrustedEmailDomain.objects.filter(domain=domain).exists()
+
+            if exists:
+                self.stdout.write(f"  SKIP  {domain} (already exists)")
+                skipped_count += 1
+                continue
+
+            if dry_run:
+                self.stdout.write(
+                    f"  WOULD CREATE  {domain}"
+                    f" ({entry['organization_name']})"
+                )
+            else:
+                TrustedEmailDomain.objects.create(
+                    domain=domain,
+                    organization_name=entry["organization_name"],
+                    auto_approve_to_community=True,
+                    notes=entry.get("notes", ""),
+                )
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"  CREATED  {domain}"
+                        f" ({entry['organization_name']})"
+                    )
+                )
+            created_count += 1
+
+        action = "Would create" if dry_run else "Created"
+        self.stdout.write(
+            f"\n{action} {created_count}, skipped {skipped_count}"
+        )

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -141,3 +141,33 @@ class TrustedEmailDomain(TimeStampedModel):
 
     def __str__(self):
         return f"{self.domain} ({self.organization_name})"
+
+    @classmethod
+    def find_matching_domain(cls, email_domain):
+        """
+        Find a TrustedEmailDomain matching the given email domain.
+        Supports both exact matches (e.g., 'mbari.org') and suffix matches
+        (e.g., 'edu' matches 'stanford.edu', 'mit.edu').
+        Returns the most specific (longest) match, or None.
+        """
+        from django.db.models import F, Value
+        from django.db.models.functions import Length
+
+        # Try exact match first
+        try:
+            return cls.objects.get(domain=email_domain)
+        except cls.DoesNotExist:
+            pass
+
+        # Try suffix match: find all trusted domains where the email domain
+        # ends with '.{trusted_domain}' (e.g., 'stanford.edu' ends with '.edu')
+        candidates = []
+        for td in cls.objects.all():
+            if email_domain.endswith(f".{td.domain}"):
+                candidates.append(td)
+
+        if not candidates:
+            return None
+
+        # Return the most specific (longest domain) match
+        return max(candidates, key=lambda td: len(td.domain))

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -74,22 +74,19 @@ class RegisterSerializer(serializers.ModelSerializer):
                 from .models import TrustedEmailDomain
 
                 domain = email.split("@")[-1].lower()
+                trusted_domain = TrustedEmailDomain.find_matching_domain(domain)
 
-                try:
-                    trusted_domain = TrustedEmailDomain.objects.get(
-                        domain=domain
+                if trusted_domain and trusted_domain.auto_approve_to_community:
+                    user.verification_notes = (
+                        f"Email domain {domain} matched trusted domain"
+                        f" '{trusted_domain.domain}'. Will auto-approve to"
+                        " Community tier after profile completion."
                     )
-                    if trusted_domain.auto_approve_to_community:
-                        user.verification_notes = (
-                            f"Email domain {domain} is whitelisted. Will"
-                            " auto-approve to Community tier after profile"
-                            " completion."
-                        )
-                        logger.info(
-                            f"User {email} registered with trusted domain"
-                            f" {domain}"
-                        )
-                except TrustedEmailDomain.DoesNotExist:
+                    logger.info(
+                        f"User {email} registered with trusted domain"
+                        f" {trusted_domain.domain}"
+                    )
+                else:
                     logger.info(
                         f"User {email} registered with non-whitelisted domain"
                         f" {domain}"
@@ -223,22 +220,19 @@ class ResearcherProfileSerializer(serializers.ModelSerializer):
         from .models import TrustedEmailDomain
 
         email_domain = instance.email.split("@")[-1].lower()
+        trusted_domain = TrustedEmailDomain.find_matching_domain(email_domain)
 
-        try:
-            trusted_domain = TrustedEmailDomain.objects.get(
-                domain=email_domain
+        if trusted_domain and trusted_domain.auto_approve_to_community:
+            instance.role = User.RESEARCHER_COMMUNITY
+            instance.verification_completed_at = timezone.now()
+            instance.verification_notes = (
+                "Auto-approved to Community tier based on trusted domain:"
+                f" '{trusted_domain.domain}' (matched {email_domain})"
             )
-            if trusted_domain.auto_approve_to_community:
-                instance.role = User.RESEARCHER_COMMUNITY
-                instance.verification_completed_at = timezone.now()
-                instance.verification_notes = (
-                    "Auto-approved to Community tier based on trusted domain:"
-                    f" {email_domain}"
-                )
-                logger.info(
-                    f"User {instance.email} auto-approved to Community tier"
-                )
-        except TrustedEmailDomain.DoesNotExist:
+            logger.info(
+                f"User {instance.email} auto-approved to Community tier"
+            )
+        else:
             # Remains pending, needs admin review
             logger.info(
                 f"User {instance.email} profile completed, awaiting admin"


### PR DESCRIPTION
## Summary
- Refactored RegisterSerializer and ResearcherProfileSerializer to utilize TrustedEmailDomain.find_matching_domain for improved domain matching.
- Enhanced user registration and profile completion flow to auto-approve users based on trusted email domains.
- Added a new management command to seed the TrustedEmailDomain table with default trusted domains, including various educational and governmental domains.
- Improved logging for user registration and profile completion events related to trusted domains.

## Motivation
Adding the trusted domains to auto-approve and fasten teh flow for users


## Impacted Components
- [ ] API
- [x] Database / schema
- [ ] Infrastructure
- [ ] Documentation
- [ ] Frontend

## Checklist
- [x] Code is documented
- [ ] Tests added or updated
- [x] No breaking changes (or clearly documented)
- [x] Follows project architecture principles
