### PR TITLE
fix(infra): make Let's Encrypt auto-renewal actually work

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,46 @@
+# .github/workflows/infra.yml
+name: Infra Validation
+
+# Infra changes don't touch backend/frontend, so the PR Validation suite skips
+# them. This workflow gives infra-only PRs their own lightweight gate.
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'infra/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/infra.yml'
+
+jobs:
+  validate-terraform:
+    name: Validate Terraform
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./infra/terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.5.7
+
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init (no backend)
+        run: terraform init -backend=false -input=false
+
+      - name: Terraform validate
+        run: terraform validate
+
+  validate-compose:
+    name: Validate Docker Compose
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate docker-compose.yml
+        run: docker compose -f docker-compose.yml config -q

--- a/infra/terraform/user-data.sh
+++ b/infra/terraform/user-data.sh
@@ -211,6 +211,8 @@ services:
     image: nginx:alpine
     container_name: species-nginx
     restart: unless-stopped
+    # Reload every 6h so freshly renewed certs are picked up without a manual restart
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     ports:
       - "80:80"
       - "443:443"
@@ -230,10 +232,13 @@ services:
   certbot:
     image: certbot/certbot
     container_name: species-certbot
+    restart: unless-stopped
     volumes:
       - certbot-conf:/etc/letsencrypt
       - certbot-www:/var/www/certbot
-    command: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $$$$!; done;'"
+    # entrypoint (not command) — the certbot image's ENTRYPOINT is "certbot",
+    # so a command: string gets passed as args to certbot instead of run by a shell.
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
 volumes:
   backend-static:
   backend-media:


### PR DESCRIPTION
## Summary

The SSL cert for `species.kuroshio-lab.com` / `api.species.kuroshio-lab.com` expired on **2026-06-02** and was found expired on 2026-06-11. Investigation showed the certbot auto-renewal had **never worked since the instance was built** — two compounding bugs in the compose generated by `user-data.sh`:

1. **Malformed renewal loop.** The `certbot/certbot` image has `ENTRYPOINT ["certbot"]`, so the compose `command:` string was passed as *arguments to certbot* rather than run by a shell. The container errored (`Unable to open config file: trap exit TERM...`) and exited (code 2) immediately. The cert was never renewed — it just coasted on its initial 90-day issuance until it lapsed.
2. **No `restart:` policy on certbot**, so the crashed container never came back and the failure was silent (no alarm).

## Changes (`infra/terraform/user-data.sh`)

- **certbot:** use `entrypoint:` instead of `command:` so the renewal loop runs under `/bin/sh`; add `restart: unless-stopped` so it survives crashes/reboots. Also fixed the `wait` PID escaping (`$$$$!` → `$${!}`).
- **nginx:** reload every 6h so freshly renewed certs are picked up without a manual restart (closes the gap where nginx serves an in-memory cert indefinitely).

## Already applied to production

The running box (`/opt/species-tracker/docker-compose.yml`) has been patched with the same changes and the cert manually renewed — now valid **2026-06-11 → 2026-09-09** on both domains, with the renewal loop confirmed running (`certbot renew` executed, reported "not yet due", now sleeping). A one-time check is scheduled for 2026-08-11 to confirm the first real auto-renewal fires.

## Verification
- `docker-compose config` validates
- `species-certbot` container stays Up and runs the renewal loop
- Live cert served with valid chain on both domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)